### PR TITLE
Added Input Sanitization

### DIFF
--- a/api/api-library/Validation/Attributes/Sanitize.php
+++ b/api/api-library/Validation/Attributes/Sanitize.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Glueful\Api\Library\Validation\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
+class Sanitize
+{
+    public function __construct(public array $filters) {}
+}


### PR DESCRIPTION
Two-Step Process:

First sanitizes the input
Then validates the sanitized value
Order ensures validation runs on clean data
Sanitization Process:

Looks for #[Sanitize] attributes on properties
Applies multiple filters in sequence
Available filters:
trim: Removes whitespace
strip_tags: Removes HTML/PHP tags
intval: Converts to integer
sanitize_email: Cleans email addresses

Benefits:

Input cleaning before validation
Multiple sanitization steps per field
Attribute-based configuration
Type-safe processing
Clear separation of concerns
Extensible filter system

The sanitization happens before validation to ensure all data is properly cleaned before being checked against the rules.