### PR TITLE
Renamed AppLogger to LogManager

### DIFF
--- a/api/API.php
+++ b/api/API.php
@@ -16,7 +16,7 @@ use Glueful\Api\Http\{
     Router
 };
 use Glueful\Api\Extensions\Uploader\FileUploader;
-use Glueful\Api\Library\Logging\AppLogger;
+use Glueful\Api\Library\Logging\LogManager;
 use Monolog\Level;
 
 /**
@@ -28,7 +28,7 @@ use Monolog\Level;
 class API 
 {
     private static bool $routesInitialized = false;
-    private static ?AppLogger $logger = null;
+    private static ?LogManager $logger = null;
     
     /**
      * Initialize the API system
@@ -38,7 +38,7 @@ class API
     public static function init(): void
     {
         if (self::$logger === null) {
-            self::$logger = new AppLogger();
+            self::$logger = new LogManager();
         }
         if (!self::$routesInitialized) {
         // Load extensions before main routes

--- a/api/api-library/APIEngine.php
+++ b/api/api-library/APIEngine.php
@@ -6,7 +6,7 @@ namespace Glueful\Api\Library;
 use Glueful\Api\Library\{QueryAction, Utils, JWTService, SessionManager};
 use Glueful\Api\Http\Response;
 use Glueful\Api\Extensions\Uploader\Storage\StorageInterface;
-use Glueful\Api\Library\Logging\AppLogger;
+use Glueful\Api\Library\Logging\LogManager;
 use Monolog\Level;
 
 /**
@@ -23,8 +23,8 @@ class APIEngine
     /** @var string Current database resource */
     private static string $currentResource;
 
-    /** @var AppLogger Logger instance */
-    private static ?AppLogger $logger = null;
+    /** @var LogManager Logger instance */
+    private static ?LogManager $logger = null;
 
     /**
      * Initialize API Engine
@@ -41,7 +41,7 @@ class APIEngine
         self::$currentResource = array_key_first(array_filter($dbConfig, 'is_array'));
         
         // Initialize logger
-        self::$logger = new AppLogger();
+        self::$logger = new LogManager();
     }
 
     /**

--- a/api/api-library/ExceptionHandler.php
+++ b/api/api-library/ExceptionHandler.php
@@ -8,7 +8,7 @@ use Glueful\Api\Exceptions\ApiException;
 use Glueful\Api\Exceptions\ValidationException;
 use Glueful\Api\Exceptions\AuthenticationException;
 use Glueful\Api\Exceptions\NotFoundException;
-use Glueful\Api\Library\Logging\AppLogger;
+use Glueful\Api\Library\Logging\LogManager;
 use Monolog\Level;
 use Throwable;
 
@@ -20,8 +20,8 @@ use Throwable;
  */
 class ExceptionHandler
 {
-    /** @var AppLogger Logger instance */
-    private static ?AppLogger $logger = null;
+    /** @var LogManager Logger instance */
+    private static ?LogManager $logger = null;
 
     /** @var array<string, string> Exception type to channel mapping */
     private static array $channelMap = [
@@ -41,7 +41,7 @@ class ExceptionHandler
     public static function register(): void
     {
         // Initialize logger
-        self::$logger = new AppLogger();
+        self::$logger = new LogManager();
         
         set_exception_handler([self::class, 'handleException']);
         register_shutdown_function([self::class, 'handleShutdown']);

--- a/api/api-library/Logging/LogManager.php
+++ b/api/api-library/Logging/LogManager.php
@@ -3,10 +3,8 @@ declare(strict_types=1);
 
 namespace Glueful\Api\Library\Logging;
 
-use PDO;
 use Monolog\Logger;
 use Monolog\Handler\RotatingFileHandler;
-use Glueful\Api\Schemas\SchemaManagerFactory;
 use Glueful\Api\Library\Utils;
 use Monolog\Level;
 use Glueful\Api\Library\Logging\DatabaseLogHandler;
@@ -28,7 +26,7 @@ use Glueful\Api\Library\Logging\DatabaseLogHandler;
  * 
  * Usage:
  * ```php
- * $logger = new AppLogger();
+ * $logger = new LogManager();
  * 
  * // Basic logging
  * $logger->log("User logged in", ['user_id' => 123], Level::Info);
@@ -39,7 +37,7 @@ use Glueful\Api\Library\Logging\DatabaseLogHandler;
  * 
  * @package Glueful\Api\Library\Logging
  */
-class AppLogger
+class LogManager
 {
     /** @var Logger Monolog logger instance */
     private Logger $logger;

--- a/api/index.php
+++ b/api/index.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 require_once __DIR__ . '/../api/bootstrap.php';
 
 use Glueful\Api\API;
-use Glueful\Api\Library\Logging\AppLogger;
+use Glueful\Api\Library\Logging\LogManager;
 use Monolog\Level;
 use Glueful\Api\Http\ServerRequestFactory;
 use Glueful\Api\Exceptions\{ValidationException, AuthenticationException};
@@ -22,7 +22,7 @@ use Glueful\Api\Exceptions\{ValidationException, AuthenticationException};
 $startTime = microtime(true);
 
 // Initialize logger
-$logger = new AppLogger();
+$logger = new LogManager();
 
 // Common request data for context
 $requestContext = [


### PR DESCRIPTION
	•	Renamed AppLogger to LogManager to better reflect its role as a centralized logging system for all events, including application, API requests, and system logs.
	•	Improved structure for future extensibility and integration with different logging handlers.