### PR TITLE
feature for updating table schemas with multiple operations in a single request, along with several refactorings to improve consistency in database schema management.

### DIFF
--- a/api/Controllers/AdminController.php
+++ b/api/Controllers/AdminController.php
@@ -1769,13 +1769,14 @@ class AdminController {
                         }
 
                         $success = $this->schemaManager->addColumn($tableName, $column['name'], $columnDef);
+                        
                         if ($success) {
                             $results['added_columns'][] = $column['name'];
                         } else {
                             $results['failed_operations'][] = "Failed to add column: " . $column['name'];
                         }
                     } catch (\Exception $e) {
-                        error_log("Failed to add column '{$column['name']}': " . $e->getMessage());
+                        error_log("Failed to add column '{$column['name']}']: " . $e->getMessage());
                         $results['failed_operations'][] = "Failed to add column: {$column['name']} - " . $e->getMessage();
                     }
                 }
@@ -1827,15 +1828,6 @@ class AdminController {
                             'column' => $fk['column'],
                             'references' => $fk['references'],
                             'on' => $fk['on'],
-                            // Optional ON DELETE/UPDATE actions
-                            'onDelete' => $fk['onDelete'] ?? null,
-                            'onUpdate' => $fk['onUpdate'] ?? null,
-                            // Generate a standard constraint name if not provided
-                            'name' => $fk['name'] ?? sprintf(
-                                "fk_%s_%s",
-                                $tableName,
-                                is_array($fk['column']) ? implode('_', $fk['column']) : $fk['column']
-                            )
                         ];
 
                         $success = $this->schemaManager->addForeignKey([$fkDef]);

--- a/api/Database/Schema/MySQLSchemaManager.php
+++ b/api/Database/Schema/MySQLSchemaManager.php
@@ -190,7 +190,8 @@ class MySQLSchemaManager implements SchemaManager
      */
     public function dropTable(string $table): bool
     {
-        return (bool) $this->pdo->exec("DROP TABLE IF EXISTS `$table`");
+        $this->pdo->exec("DROP TABLE IF EXISTS `$table`");
+        return true;
     }
 
     /**
@@ -212,7 +213,10 @@ class MySQLSchemaManager implements SchemaManager
         $sql = "ALTER TABLE `$table` ADD `$column` {$definition['type']} " .
                (!empty($definition['nullable']) ? 'NULL' : 'NOT NULL') .
                (!empty($definition['default']) ? " DEFAULT '{$definition['default']}'" : '');
-        return (bool) $this->pdo->exec($sql);
+        
+        // Execute the query - if it doesn't throw an exception, consider it successful
+        $this->pdo->exec($sql);
+        return true;
     }
 
     /**
@@ -227,7 +231,8 @@ class MySQLSchemaManager implements SchemaManager
      */
     public function dropColumn(string $table, string $column): bool
     {
-        return (bool) $this->pdo->exec("ALTER TABLE `$table` DROP COLUMN `$column`");
+        $this->pdo->exec("ALTER TABLE `$table` DROP COLUMN `$column`");
+        return true;
     }
 
     /**
@@ -261,7 +266,8 @@ class MySQLSchemaManager implements SchemaManager
      */
     public function dropIndex(string $table, string $indexName): bool
     {
-        return (bool) $this->pdo->exec("DROP INDEX `$indexName` ON `$table`");
+        $this->pdo->exec("DROP INDEX `$indexName` ON `$table`");
+        return true;
     }
     
     /**
@@ -523,6 +529,7 @@ class MySQLSchemaManager implements SchemaManager
         
         // Foreign key exists, so drop it
         $sql = "ALTER TABLE `$table` DROP FOREIGN KEY `$constraintName`";
-        return (bool) $this->pdo->exec($sql);
+        $this->pdo->exec($sql);
+        return true;
     }
 }

--- a/api/Database/Schema/PostgreSQLSchemaManager.php
+++ b/api/Database/Schema/PostgreSQLSchemaManager.php
@@ -220,7 +220,8 @@ class PostgreSQLSchemaManager extends SchemaManager
     {
         try {
             $sql = "DROP TABLE IF EXISTS {$table} CASCADE;";
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error dropping table '{$table}': " . $e->getMessage());
         }
@@ -250,7 +251,10 @@ class PostgreSQLSchemaManager extends SchemaManager
         try {
             $columnDef = implode(' ', $definition);
             $sql = "ALTER TABLE {$table} ADD COLUMN {$column} {$columnDef};";
-            return $this->pdo->exec($sql) !== false;
+            
+            // Execute the query - if it doesn't throw an exception, consider it successful
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error adding column '{$column}' to table '{$table}': " . $e->getMessage());
         }
@@ -270,7 +274,8 @@ class PostgreSQLSchemaManager extends SchemaManager
     {
         try {
             $sql = "ALTER TABLE {$table} DROP COLUMN IF EXISTS {$column} CASCADE;";
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error dropping column '{$column}' from table '{$table}': " . $e->getMessage());
         }
@@ -303,7 +308,8 @@ class PostgreSQLSchemaManager extends SchemaManager
             $columnsSql = implode(', ', $columns);
             $sql = "CREATE {$uniqueSql} INDEX IF NOT EXISTS {$indexName} ON {$table} ({$columnsSql});";
 
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error creating index '{$indexName}' on table '{$table}': " . $e->getMessage());
         }
@@ -323,7 +329,8 @@ class PostgreSQLSchemaManager extends SchemaManager
     {
         try {
             $sql = "DROP INDEX IF EXISTS {$indexName};";
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error dropping index '{$indexName}' from table '{$table}': " . $e->getMessage());
         }

--- a/api/Database/Schema/SQLiteSchemaManager.php
+++ b/api/Database/Schema/SQLiteSchemaManager.php
@@ -212,7 +212,8 @@ class SQLiteSchemaManager implements SchemaManager
     {
         try {
             $sql = "DROP TABLE IF EXISTS {$table};";
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error dropping table '{$table}': " . $e->getMessage());
         }
@@ -241,7 +242,10 @@ class SQLiteSchemaManager implements SchemaManager
         try {
             $columnDef = implode(' ', $definition);
             $sql = "ALTER TABLE {$table} ADD COLUMN {$column} {$columnDef};";
-            return $this->pdo->exec($sql) !== false;
+            
+            // Execute the query - if it doesn't throw an exception, consider it successful
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error adding column '{$column}' to table '{$table}': " . $e->getMessage());
         }
@@ -293,7 +297,8 @@ class SQLiteSchemaManager implements SchemaManager
             $columnsSql = implode(', ', $columns);
             $sql = "CREATE {$uniqueSql} INDEX IF NOT EXISTS {$indexName} ON {$table} ({$columnsSql});";
 
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error creating index '{$indexName}' on table '{$table}': " . $e->getMessage());
         }
@@ -313,7 +318,8 @@ class SQLiteSchemaManager implements SchemaManager
     {
         try {
             $sql = "DROP INDEX IF EXISTS {$indexName};";
-            return $this->pdo->exec($sql) !== false;
+            $this->pdo->exec($sql);
+            return true;
         } catch (Exception $e) {
             throw new Exception("Error dropping index '{$indexName}' from table '{$table}': " . $e->getMessage());
         }

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -341,6 +341,22 @@ Router::group('/admin', function() use ($controller) {
         Router::post('/table/foreign-key/add-batch', function (Request $request) use ($controller){
             return $controller->addForeignKey($request);
         });
+
+        /**
+         * @route POST /admin/db/table/schema/update
+         * @tag Database
+         * @summary Update table schema
+         * @description Updates table schema with multiple operations including adding/removing columns, indexes, and foreign keys
+         * @requiresAuth true
+         * @requestBody table_name:string="Table name" columns:array=[{name:string,type:string,options:object}] indexes:array=[{column:string,type:string}] foreign_keys:array=[{column:string,references:string,on:string}] deleted_columns:array=[string] deleted_indexes:array=[string] deleted_foreign_keys:array=[string] {required=table_name}
+         * @response 200 application/json "Schema updated successfully" {added_columns:array,deleted_columns:array,added_indexes:array,deleted_indexes:array,added_foreign_keys:array,deleted_foreign_keys:array}
+         * @response 400 application/json "Invalid request format"
+         * @response 403 application/json "Permission denied"
+         * @response 404 application/json "Table not found"
+         */
+        Router::post('/table/schema/update', function (Request $request) use ($controller){
+            return $controller->updateTableSchema($request);
+        });
     }, requiresAdminAuth: true);
 
     


### PR DESCRIPTION
This pull request introduces a new feature for updating table schemas with multiple operations in a single request, along with several refactorings to improve consistency in database schema management. The key changes include the addition of a new `updateTableSchema` method in the `AdminController`, updates to database schema manager methods for MySQL, PostgreSQL, and SQLite, and the addition of a new API route.

### New Feature: Update Table Schema
* Added the `updateTableSchema` method in `AdminController` to handle multiple schema operations (e.g., adding/removing columns, indexes, and foreign keys) in a single request. This includes detailed error handling and structured responses. (`api/Controllers/AdminController.php`, [api/Controllers/AdminController.phpR1668-R1864](diffhunk://#diff-cfbe2a7c2c54ebf65985692672c20ee0ad07e7c3857a29dd3aecf69b84ae92a3R1668-R1864))
* Introduced a new API route `/admin/db/table/schema/update` to expose the `updateTableSchema` functionality. This route supports operations like adding/removing schema elements and validates the request format. (`routes/admin.php`, [routes/admin.phpR344-R359](diffhunk://#diff-8e53284cc02e19d2a64c302fe6af015f416657e24700fc55653c3956640ec436R344-R359))

### Database Schema Manager Refactoring
* Updated the `dropTable`, `addColumn`, `dropColumn`, `createIndex`, and `dropIndex` methods in MySQL, PostgreSQL, and SQLite schema managers to remove unnecessary boolean casting and rely on exceptions for error handling. These methods now return `true` upon successful execution. (`api/Database/Schema/MySQLSchemaManager.php`, [[1]](diffhunk://#diff-62f738219e48e4e0deef7bf751ae89df519b84835d66acd87edafa7157d5d1b1L193-R194) [[2]](diffhunk://#diff-62f738219e48e4e0deef7bf751ae89df519b84835d66acd87edafa7157d5d1b1L215-R219) [[3]](diffhunk://#diff-62f738219e48e4e0deef7bf751ae89df519b84835d66acd87edafa7157d5d1b1L230-R235) [[4]](diffhunk://#diff-62f738219e48e4e0deef7bf751ae89df519b84835d66acd87edafa7157d5d1b1L264-R270) [[5]](diffhunk://#diff-62f738219e48e4e0deef7bf751ae89df519b84835d66acd87edafa7157d5d1b1L526-R533); `api/Database/Schema/PostgreSQLSchemaManager.php`, [[6]](diffhunk://#diff-9364d64acfe37afdd84f83668f004969c5f40aa3ba052113ca8f2665f701c593L223-R224) [[7]](diffhunk://#diff-9364d64acfe37afdd84f83668f004969c5f40aa3ba052113ca8f2665f701c593L253-R257) [[8]](diffhunk://#diff-9364d64acfe37afdd84f83668f004969c5f40aa3ba052113ca8f2665f701c593L273-R278) [[9]](diffhunk://#diff-9364d64acfe37afdd84f83668f004969c5f40aa3ba052113ca8f2665f701c593L306-R312) [[10]](diffhunk://#diff-9364d64acfe37afdd84f83668f004969c5f40aa3ba052113ca8f2665f701c593L326-R333); `api/Database/Schema/SQLiteSchemaManager.php`, [[11]](diffhunk://#diff-3b014f8845408efbe8fd13fff1609552187b67eb983e4844d1c2e92ff3aad6b4L215-R216) [[12]](diffhunk://#diff-3b014f8845408efbe8fd13fff1609552187b67eb983e4844d1c2e92ff3aad6b4L244-R248) [[13]](diffhunk://#diff-3b014f8845408efbe8fd13fff1609552187b67eb983e4844d1c2e92ff3aad6b4L296-R301) [[14]](diffhunk://#diff-3b014f8845408efbe8fd13fff1609552187b67eb983e4844d1c2e92ff3aad6b4L316-R322)