### PR TITLE
PostgreSQL Connection Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the Glueful framework will be documented in this file.
 
+## [0.32.2] - 2025-08-10
+
+### Fixed
+- **PostgreSQL Connection Error**
+  - Fixed "invalid connection option 'search_path'" error preventing PostgreSQL connections
+  - Removed `search_path` from PostgreSQL DSN string where it's not a valid connection parameter
+  - Properly set search_path using SQL command after connection is established
+  - Applied fix to both Connection.php and ConnectionPool.php for consistency
+  - Ensures PostgreSQL schema configuration works correctly across all connection types
+
 ## [0.32.1] - 2025-08-09
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current Status
 
-**Latest Release:** v0.32.1 (August 9, 2025)  
+**Latest Release:** v0.32.2 (August 10, 2025)  
 **Next Target:** v1.0.0
 
 ## Path to Stable Release
@@ -101,6 +101,15 @@
   - Extensions.json restored before running extension migrations
   - Ensures RBAC and other extension database tables are created
   - Added graceful error handling for extension migration failures
+
+### 🏁 **v0.32.2** - PostgreSQL Connection Fix ✅ **RELEASED**
+**Critical database connectivity fix**
+
+- ✅ **PostgreSQL Connection Error**
+  - Fixed "invalid connection option 'search_path'" error
+  - Removed search_path from DSN string where it's not valid
+  - Properly set search_path using SQL command after connection
+  - Ensures PostgreSQL schema configuration works correctly
 
 ### 🎯 **v0.33.0** - Final Pre-Release
 **Focus: Complete preparation for v1.0.0 stable release**

--- a/api/Database/ConnectionPoolManager.php
+++ b/api/Database/ConnectionPoolManager.php
@@ -84,7 +84,15 @@ class ConnectionPoolManager
             $username = $engine !== 'sqlite' ? ($dbConfig['user'] ?? null) : null;
             $password = $engine !== 'sqlite' ? ($dbConfig['pass'] ?? null) : null;
 
-            $this->pools[$engine] = new ConnectionPool($config, $dsn, $username, $password, $options, $driver);
+            $this->pools[$engine] = new ConnectionPool(
+                $config,
+                $dsn,
+                $username,
+                $password,
+                $options,
+                $driver,
+                $dbConfig
+            );
         }
 
         return $this->pools[$engine];
@@ -195,12 +203,11 @@ class ConnectionPoolManager
                 $config['charset'] ?? 'utf8mb4'
             ),
             'pgsql' => sprintf(
-                'pgsql:host=%s;dbname=%s;port=%d;sslmode=%s;search_path=%s',
+                'pgsql:host=%s;dbname=%s;port=%d;sslmode=%s',
                 $config['host'] ?? '127.0.0.1',
                 $config['db'] ?? '',
                 $config['port'] ?? 5432,
-                $config['sslmode'] ?? 'prefer',
-                $config['schema'] ?? 'public'
+                $config['sslmode'] ?? 'prefer'
             ),
             'sqlite' => $this->prepareSQLiteDSN($config['primary'] ?? ':memory:'),
             default => throw new \Exception("Unsupported database engine: {$engine}"),

--- a/api/version.php
+++ b/api/version.php
@@ -9,8 +9,8 @@
  */
 
 return [
-    'version' => '0.32.1',
-    'name' => 'Cache Compatibility & Extension Migrations',
-    'release_date' => '2025-08-09',
+    'version' => '0.32.2',
+    'name' => 'PostgreSQL Connection Fix',
+    'release_date' => '2025-08-10',
     'min_php_version' => '8.2.0'
 ];


### PR DESCRIPTION
### Fixed
- **PostgreSQL Connection Error**
  - Fixed "invalid connection option 'search_path'" error preventing PostgreSQL connections
  - Removed `search_path` from PostgreSQL DSN string where it's not a valid connection parameter
  - Properly set search_path using SQL command after connection is established
  - Applied fix to both Connection.php and ConnectionPool.php for consistency
  - Ensures PostgreSQL schema configuration works correctly across all connection types

